### PR TITLE
Guard context-specific POS_CHANGE writes behind --truth_set (fixes -CG/-CH crash without --truth_set)

### DIFF
--- a/Sherman
+++ b/Sherman
@@ -834,6 +834,7 @@ sub bisulfite_transform_sequences_context_specifically{
             $bases[$index] = 'T';
             $converted_CG_count++;
 
+            if ($truth_set){
             if ($direction eq "left") {
             print POS_CHANGE "$chrom\t";
             print POS_CHANGE $start_pos + $base_counter;
@@ -846,6 +847,7 @@ sub bisulfite_transform_sequences_context_specifically{
             print POS_CHANGE $start_pos - length($seq) + $base_counter - 1;
             print POS_CHANGE "\tconverted_CG\n";
             }    
+            }
           }
 	}
 	else {
@@ -855,6 +857,7 @@ sub bisulfite_transform_sequences_context_specifically{
 	    $bases[$index] = 'T';
 	    $converted_CH_count++;
 
+            if ($truth_set){
          if ($direction eq "left") {
 			print POS_CHANGE "$chrom\t";
 			print POS_CHANGE $start_pos + $base_counter;
@@ -866,6 +869,7 @@ sub bisulfite_transform_sequences_context_specifically{
 			print POS_CHANGE $start_pos - length($seq) + $base_counter - 1;
 			print POS_CHANGE "\tconverted_CH\n";
 		  }
+            }
   
 
 	    


### PR DESCRIPTION
Running context-specific bisulfite conversion (`-CG`/`-CH`) **without** `--truth_set` currently dies:

```
print() on unopened filehandle POS_CHANGE at Sherman line 859, <CHR_IN> line ...
```

### Cause
In `bisulfite_transform_sequences_context_specifically`, the **CpG** and **non-CpG (CH)** position-logging blocks write to the `POS_CHANGE` filehandle **unconditionally**. That is inconsistent with:
- the *third* block in the same sub (the "last position / assume CH" case), which already guards its writes with `if ($truth_set)`, and
- every `POS_CHANGE` block in the sibling `bisulfite_transform_sequences_uniformly`, which are all guarded.

`POS_CHANGE` is only `open`ed when `--truth_set` is given, so the two unguarded blocks print to an unopened handle whenever context-specific conversion runs without `--truth_set` — which aborts the run (no reads written).

### Fix
Wrap both blocks in `if ($truth_set){ ... }`, matching the rest of the file. No change to the bisulfite-conversion logic, and `positional_changes.txt` output under `--truth_set` is unchanged (the inner lines are byte-identical).

### Testing
`perl -c Sherman` passes. On a small genome, `Sherman -l 40 -n 200 -pe -CG 25 -CH 98 -e 0.1`:
- **before:** crashes with the unopened-filehandle error (no output);
- **after:** runs to completion and writes `simulated_1.fastq` / `simulated_2.fastq` — both **without** and **with** `--truth_set` (the latter also writes `positional_changes.txt`).

### Note (separate, not addressed here)
With `--truth_set` on a large multi-contig genome I separately saw `Argument "" isn't numeric in addition (+)` at the `$start_pos + $base_counter` print, suggesting `$start_pos` can be empty on one PE call path — likely a caller arg-order issue worth a look, independent of this guard fix.