### PR TITLE
Reject contig-boundary-straddling fragments in paired-end generation (fixes the multi-contig --truth_set crash noted in #16)

### DIFF
--- a/Sherman
+++ b/Sherman
@@ -1368,6 +1368,7 @@ sub generate_genomic_sequences_paired_end {
 				last unless ($chromosome_length - $fragment_length > $random );
 
 				my $offset = $random - ($chromosome_length - length ($chromosomes{$chr}) );
+				last if ($offset < 0); # fragment straddles the previous contig boundary; redraw a new position
 				# warn "Offset: $offset\n";
 				$seq_1 = substr ($chromosomes{$chr},$offset,$sequence_length);
 				$seq_2 = substr ($chromosomes{$chr},$offset + $fragment_length - $sequence_length,$sequence_length);


### PR DESCRIPTION
## Problem

This is the **"separate, not addressed here"** issue noted in #16:

> With `--truth_set` on a large multi-contig genome I separately saw `Argument "" isn't numeric in addition (+)` at the `$start_pos + $base_counter` print, suggesting `$start_pos` can be empty on one PE call path.

It is **not** an arg-order problem — it's a fragment-generation bug in `generate_genomic_sequences_paired_end`, and it only manifests with **≥2 contigs**.

## Cause

A random fragment start can land in the last `fragment_length` coordinate bases of a contig. The *previous* contig then fails the `($random+$fragment_length) < $chromosome_length` test and is skipped; the *next* contig matches, and `$offset = $random - cum_before_current` evaluates **negative**.

A negative `$offset` is doubly wrong:

1. **Silent data corruption (even without `--truth_set`):** `substr($chromosomes{$chr}, $offset, ...)` counts from the **end of the wrong contig**, so the read is real sequence from the wrong place — full length, so it slips past the existing N- and length-checks.
2. **Crash with `--truth_set`:** `$coords` becomes e.g. `chr2:-399--1`; the caller's `split(':')`/`split('-')` parsing yields an empty `$left_start`, which reaches `print POS_CHANGE $start_pos + $base_counter` → `Argument "" isn't numeric in addition (+)` and aborts the run.

Only reachable with ≥2 contigs, which is why it shows up on large multi-contig genomes.

## Fix

Reject the straddling fragment with `last if ($offset < 0);`, matching the existing rejection-sampling style (N-containing and wrong-length fragments are already rejected the same way); the enclosing `until ($valid)` loop simply redraws. Fixes **both** the crash and the silent wrong-sequence bug at the root, with no change to coordinate math or output for valid fragments.

### Why not just harden the coordinate parser?
Parser-hardening would silence the crash but leave the wrong-sequence reads (from the negative-offset `substr`) in the output. The offset guard fixes the actual defect.

## Testing

2×1000 bp genome, `-pe --truth_set --minfrag 200 --maxfrag 400`:
- **before:** `Argument "" isn't numeric in addition (+) at Sherman line 746`;
- **after:** runs to completion (5000 reads, all outputs); the guard fires 1169×/run; all 89,904 logged positions are valid integers within contig bounds; single-contig behaviour unchanged; `perl -c` passes.

## Related, *not* addressed here
- Single-end `generate_genomic_sequences` uses a different/also-suspicious offset scheme (and `length($sequence_length)` looks like a typo) — separate review.
- `--non_directional` swaps `$seq_1`/`$seq_2` but not the `left`/`right` coordinate labels — separate `--truth_set` mislabeling issue.
- A contig name containing `:` would over-split the coords independently of this bug — would need parser hardening.
- Latent: if every contig is shorter than `--maxfrag`, `until ($valid)` loops forever (pre-existing; neither introduced nor fixed here).