### PR TITLE
Add --amplicon_bedfile mode (paired-end) — forward-port of the amplicon feature, fixes #13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Added option `--amplicon_bedfile <file>` (paired-end only): instead of random fragments, simulate reads for fixed amplicon loci from a 4-column, 0-based half-open BED (chromosome, start, end, strand). Read 1 starts at each amplicon start and read 2 ends at each amplicon end, sampled equally across all amplicons. Truth-set coordinates are computed correctly for both strands. Resolves [#13](https://github.com/FelixKrueger/Sherman/issues/13).
+
 ## 11-07-2022: Sherman Version v0.1.9 released
 
 - Added option `--truth_set` to write out a file 'positional_changes.txt' containing chromosome, position and C-context (tab-delimited). More [here](https://github.com/FelixKrueger/Sherman/pull/9). 

--- a/Sherman
+++ b/Sherman
@@ -27,6 +27,7 @@ my $total_genome_length = 0; ## we need this later to generate random sequences
 my %chromosomes;
 my %seqs;             # single-end reads or read 1 of paired-end reads
 my %seqs_pairs;       # read 2 of paired-end reads
+my %amplicons;        # amplicon loci (chr:start:end:strand) when --amplicon_bedfile is used
 
 my %counting =(
 	       non_directional => 0,
@@ -44,12 +45,22 @@ my @DNA_bases = ('A','T','C','G');
 my @gaussian; # will hold random fragment lengths
 
 my ($sequence_length,$conversion_rate,$number_of_sequences,$error_rate,$number_of_SNPs,$quality,$fixed_length_adapter,$variable_length_adapter,$adapter_dimer,$random,$colorspace,
-$genome_folder,$non_directional,$CG_conversion_rate,$CH_conversion_rate,$paired_end,$minfrag,$maxfrag,$output_dir,$truth_set) = process_command_line();
+$genome_folder,$non_directional,$CG_conversion_rate,$CH_conversion_rate,$paired_end,$minfrag,$maxfrag,$output_dir,$truth_set,$amplicon) = process_command_line();
 
 print_onscreen_summary();
 run_sequence_generation();
 
 sub print_onscreen_summary{
+
+  if ($amplicon){
+    warn "AMPLICON MODE VIA BEDFILE - the start and end reads of all amplicons in the bedfile are simulated equally. Using the following loci:\n\n##############################\n\n";
+    foreach my $amp (sort {$a<=>$b} keys %amplicons){
+      warn "$amp\t$amplicons{$amp}\n";
+    }
+    warn "\n##############################\n\n";
+    sleep(1);
+  }
+
   warn "\nSelected general parameters:\n";
   warn "-"x100,"\n";
   if ($paired_end){
@@ -226,7 +237,12 @@ sub run_sequence_generation{
       if ($paired_end){
 		    
 	  	  my ($g0_1,$step_1,$g0_2,$step_2);
-	  	  ($seq_1,$seq_2,$strand,$genomic_coords,$g0_1,$step_1,$g0_2,$step_2) = generate_genomic_sequences_paired_end($conversion_rate);
+	  	  if ($amplicon){
+	  	    ($seq_1,$seq_2,$strand,$genomic_coords,$g0_1,$step_1,$g0_2,$step_2) = generate_genomic_sequences_paired_end_amplicon($conversion_rate);
+	  	  }
+	  	  else{
+	  	    ($seq_1,$seq_2,$strand,$genomic_coords,$g0_1,$step_1,$g0_2,$step_2) = generate_genomic_sequences_paired_end($conversion_rate);
+	  	  }
 				my @spl;
         my @spl_1;
 
@@ -1406,6 +1422,77 @@ sub generate_genomic_sequences_paired_end {
 }
 
 
+sub generate_genomic_sequences_paired_end_amplicon {
+    my $conversion_rate = shift;
+
+    # Pick one amplicon at random (uniform over the loci supplied in the bedfile).
+    # Each value is stored as "chr:start:end:strand"; bed coords are 0-based, half-open.
+    my ($chr,$start,$end,$strand) = (split(":",$amplicons{int(rand(scalar keys %amplicons)+1)}))[0,1,2,3];
+
+    my $seq_1;
+    my $seq_2;
+    my $coords;
+    my ($g0_1,$step_1,$g0_2,$step_2); # truth_set: genomic coord of each read's 5' base + travel direction (+1 fwd / -1 revcomp)
+    my $plus = 0;
+    my $minus = 0;
+    my $read2_start;
+
+    ### Guards (amplicon loci are fixed, so fail loudly rather than silently emit wrong reads)
+    unless (exists $chromosomes{$chr}){
+      die "Amplicon contig '$chr' was not found in the genome\n";
+    }
+    unless ($end <= length $chromosomes{$chr}){
+      die "Cannot extract amplicon $chr:$start-$end: the end lies beyond the contig length (".length($chromosomes{$chr})." bp)\n";
+    }
+    if ( ($end - $start) < $sequence_length ){
+      die "Amplicon $chr:$start-$end is shorter than the read length; cannot simulate fixed-endpoint reads\n";
+    }
+
+    if ($strand eq '+'){
+      # READ1 starts at the amplicon start (bed is 0-based, half-open, so no down-adjustment);
+      # READ2 ends at the amplicon end (it is reverse-complemented later, in the caller).
+      $read2_start = $end - $sequence_length + 1;
+      $seq_1 = substr ($chromosomes{$chr},$start,$sequence_length);
+      $seq_2 = substr ($chromosomes{$chr},$read2_start,$sequence_length);
+      ++$plus;
+      $coords = "${chr}:".($start).'-'.($end);
+      $g0_1 = $start + 1;          $step_1 = 1;   # seq_1 forward from genomic start+1
+      $g0_2 = $read2_start + 1;    $step_2 = 1;   # seq_2 forward from genomic read2_start+1
+    }
+    elsif ($strand eq '-'){
+      my $read1_start = $end - $sequence_length;
+      if ($start - 1 < 0 or $read1_start < 0){
+        die "Cannot extract amplicon $chr:$start-$end on the minus strand: a read offset would be negative\n";
+      }
+      $seq_2 = substr ($chromosomes{$chr},$start - 1,$sequence_length);
+      $seq_1 = substr ($chromosomes{$chr},$read1_start,$sequence_length);
+      $seq_1 = reverse_complement($seq_1);
+      $seq_2 = reverse_complement($seq_2);
+      ++$minus;
+      $coords = "${chr}:".($start).'-'.($end);
+      # both reads are reverse complements of their genomic windows: the 5' base maps to the
+      # window's 3' end and walks backwards along the genome.
+      $g0_1 = $end;                          $step_1 = -1;  # seq_1 window genomic (end-L+1 .. end)
+      $g0_2 = ($start - 1) + $sequence_length; $step_2 = -1; # seq_2 window genomic (start .. start+L-1)
+    }
+
+    # amplicon loci are fixed, so an N-containing or wrong-length window is a hard error (not a re-roll)
+    if ($seq_1 =~ /n/i or $seq_2 =~ /n/i){
+      die "Amplicon read seq1 ($seq_1) or seq2 ($seq_2) contained N(s); please choose amplicons in N-free regions\n";
+    }
+    if (length$seq_1 != $sequence_length or length$seq_2 != $sequence_length){
+      die "The length of seq1 or seq2 were not equal to the sequence length of $sequence_length\n";
+    }
+
+    if($plus == 1){
+      return ($seq_1,$seq_2,'plus',$coords,$g0_1,$step_1,$g0_2,$step_2);
+    }
+    else{
+      return ($seq_1,$seq_2,'minus',$coords,$g0_1,$step_1,$g0_2,$step_2);
+    }
+}
+
+
 sub generate_random_sequences {
 
   my @seq;
@@ -1626,6 +1713,7 @@ sub process_command_line{
 	my $version;
 	my $output_dir;
   my $truth_set;
+  my $amplicon_bed;
 
 	my $command_line = GetOptions (
 				'help|man'                   => \$help,
@@ -1650,6 +1738,7 @@ sub process_command_line{
 				'version'                    => \$version,
 				'output_dir=s'               => \$output_dir,
         'truth_set'                  => \$truth_set,
+        'amplicon_bedfile=s'         => \$amplicon_bed,
  				);
 
 
@@ -1923,8 +2012,57 @@ VERSION
     $maxfrag = 0;
   }
 
+  ### AMPLICON SIMULATION VIA BEDFILE
+  if (defined $amplicon_bed){
+
+    # Amplicon mode samples from genomic loci, so it is incompatible with --random
+    if ($random){
+      die "Amplicon simulation (--amplicon_bedfile) cannot be combined with --random mode\n";
+    }
+    # Only generating paired-end simulations (the user can always choose to ignore R2)
+    unless ($paired_end){
+      die "Amplicon simulation is only available for paired-end simulations\n";
+    }
+    unless (-f $amplicon_bed){
+      die "The specified amplicon bedfile $amplicon_bed does not exist!\n";
+    }
+
+    open (BED,$amplicon_bed) or die "Failed to open amplicon bedfile $amplicon_bed: $!\n";
+
+    # storing the amplicon coordinates in a hash; expecting a 4-column, tab-delimited,
+    # 0-based half-open bed: chr <TAB> start <TAB> end <TAB> strand(+/-)
+    my $amplicon_count = 0;
+    while (my $line = <BED>){
+      chomp $line;
+      $line =~ s/\r$//;          # tolerate Windows line endings
+      next unless ($line =~ /\S/);   # skip blank lines
+
+      my @cols = split (/\t/,$line);
+      if (scalar @cols != 4){
+        die "The amplicon bedfile $amplicon_bed does not seem to be in the correct format (4 tab-separated columns required: chr start end strand). Offending line:\n$line\n";
+      }
+      my ($chr,$start,$end,$strand) = @cols;
+      unless ($start =~ /^\d+$/ and $end =~ /^\d+$/){
+        die "The amplicon bedfile $amplicon_bed has non-numeric start/end coordinates. Offending line:\n$line\n";
+      }
+      unless ($strand eq '+' or $strand eq '-'){
+        die "The amplicon strand '$strand' is not in the correct format (+ or -), please adjust the bedfile. Offending line:\n$line\n";
+      }
+      if ($start >= $end){
+        die "The amplicon start ($start) must be smaller than the end ($end). Offending line:\n$line\n";
+      }
+      ++$amplicon_count;
+      $amplicons{$amplicon_count} = "$chr:$start:$end:$strand";
+    }
+    close BED;
+
+    unless ($amplicon_count){
+      die "The amplicon bedfile $amplicon_bed did not contain any valid amplicon loci\n";
+    }
+  }
+
   return ($length,$conversion_rate,$number_of_seqs,$error_rate,$snps,$quality,$fixed_length_adapter,$variable_length_adapter,$adapter_dimer,$random,
-  $colorspace,$genome_folder,$non_directional,$CG_conversion_rate,$CH_conversion_rate,$paired_end,$minfrag,$maxfrag,$output_dir,$truth_set);
+  $colorspace,$genome_folder,$non_directional,$CG_conversion_rate,$CH_conversion_rate,$paired_end,$minfrag,$maxfrag,$output_dir,$truth_set,$amplicon_bed);
 }
 
 sub print_helpfile{
@@ -1985,8 +2123,15 @@ BASIC ATTRIBUTES:
 
 --truth_set                       This option writes out a 'truth set' of positions that underwent bisulfite conversion.
                                   This is not available in --random mode or when the conversion rate is 0. Default: OFF.
-                                  The output format is (tab-delimited): 
-                                  >> chromosome <<   \t   >> position <<   \t   >> context << 
+                                  The output format is (tab-delimited):
+                                  >> chromosome <<   \t   >> position <<   \t   >> context <<
+
+--amplicon_bedfile <file>         Amplicon mode (paired-end only). Instead of sampling random fragments, simulate reads
+                                  for the fixed amplicon loci listed in <file>: read 1 starts at each amplicon start and
+                                  read 2 ends at each amplicon end, sampled equally across all amplicons. The bedfile must
+                                  be tab-delimited with 4 columns: chromosome, start, end, strand (+/-). Coordinates are
+                                  0-based and half-open (as is custom for BED). Supply primer-trimmed coordinates if you do
+                                  not want the primer regions to receive simulated methylation/conversion.
 
 
 CONTAMINANTS:


### PR DESCRIPTION
Resolves #13.

## Background
The amplicon-simulation feature was originally added in #14 but only ever landed on the `dev` branch — it never reached `master`, and on `dev` it predates the truth-set rewrite (#18), so its `--truth_set` coordinates were wrong. This PR **forward-ports** the feature onto `master` and adapts it to the current `(g0, step)` truth-set interface, so amplicon mode works *and* logs correct coordinates.

## What it does
`--amplicon_bedfile <file>` (paired-end only): instead of sampling random fragments, simulate reads for the fixed amplicon loci in a BED file — **read 1 starts at each amplicon start, read 2 ends at each amplicon end**, sampled equally across all amplicons. Conversion / errors / SNPs apply as normal in the interior.

- Bed format: **tab-delimited, 4 columns** `chr  start  end  strand(+/-)`, **0-based half-open**.
- Supply primer-trimmed coordinates if you don't want primer regions to receive simulated methylation (as discussed in #13).

## Truth-set correctness
`generate_genomic_sequences_paired_end_amplicon` returns a per-read `(g0, step)` mapping (g0 = genomic coordinate of the read's 5′ base, step = +1 forward / −1 reverse-complement), so each converted C is logged at `g0 + step*(base_counter-1)` — correct for both strands, uniform and context-specific, directional and `--non_directional`. The dev `+`/`-` `substr` asymmetry was verified empirically to be **correct** (it compensates for the reverse-complement + 1-bp trim) and is preserved unchanged.

## Hardening beyond the dev original
- Bed parser skips blank lines and dies on an empty/malformed bed (4-col, numeric coords, valid strand, `start < end`).
- Generator guards against: missing contig, amplicon shorter than the read length, amplicon end beyond the contig, and **negative `substr` offsets** (which on dev would silently extract the wrong sequence).
- `--amplicon_bedfile` is rejected when combined with `--random` or single-end.

## Verification
- **Placement (base resolution, cr=0, e=0):** `+` amplicon `[100,200)` → R1 101–150, R2 151–200; `-` amplicon `[300,400)` → R1 351–400 (RC), R2 301–350. Amplicon covered exactly on both strands.
- **Truth set:** **0%** of logged positions fall on a reference A/T (a wrong mapping scatters to ~49%), across uniform/context-specific × directional/non-directional.
- **Error handling:** all seven misuse cases die with clear messages.
- **No regression:** non-amplicon SE/PE (incl. `--truth_set`, `-CG/-CH`) unchanged. `perl -c` passes.

## Scope
Amplicon only — dev's other divergent commits (e.g. `--bwa_ending`) are intentionally **not** included.