### PR TITLE
Add --bwa_ending option (BWA-style /1,/2 read names) + document recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## Unreleased
 
-- Added option `--amplicon_bedfile <file>` (paired-end only): instead of random fragments, simulate reads for fixed amplicon loci from a 4-column, 0-based half-open BED (chromosome, start, end, strand). Read 1 starts at each amplicon start and read 2 ends at each amplicon end, sampled equally across all amplicons. Truth-set coordinates are computed correctly for both strands. Resolves [#13](https://github.com/FelixKrueger/Sherman/issues/13).
+### Added
+
+- New option `--amplicon_bedfile <file>` (paired-end only): instead of sampling random fragments, simulate reads for the fixed amplicon loci listed in a 4-column, tab-delimited, 0-based half-open BED (chromosome, start, end, strand). Read 1 starts at each amplicon start and read 2 ends at each amplicon end, sampled equally across all amplicons. Truth-set coordinates are correct for both strands, and the bedfile is validated (4 columns, valid strand, `start < end`, amplicon ≥ read length, within-contig). Resolves [#13](https://github.com/FelixKrueger/Sherman/issues/13).
+- New option `--bwa_ending`: for paired-end reads, name read IDs `xxx/1` and `xxx/2` (BWA-style) instead of the default `xxx_R1` / `xxx_R2`, for compatibility with BWA-based aligners. Addresses [#5](https://github.com/FelixKrueger/Sherman/issues/5).
+
+### Fixed
+
+- **`--truth_set` coordinates are now correct for all read orientations** ([#15](https://github.com/FelixKrueger/Sherman/issues/15)). Previously the logged positions could be off by one (forward reads) or grossly mismapped onto the wrong fragment end / strand (reverse-complemented reads), so a large fraction of `positional_changes.txt` positions landed on reference A/T bases. Positions are now derived per read from a genomic anchor plus a travel direction, and are correct for single-end and paired-end, both strands, both mates, directional and `--non_directional`, uniform and context-specific conversion. The simulated reads themselves are unchanged.
+- **Context-specific conversion (`-CG`/`-CH`) no longer crashes without `--truth_set`** — the `POS_CHANGE` writes are now properly guarded.
+- **Paired-end fragments no longer straddle contig boundaries** on multi-contig genomes, which previously produced reads from the wrong contig and a `--truth_set` crash (`Argument "" isn't numeric`). Such fragments are now rejected and resampled.
 
 ## 11-07-2022: Sherman Version v0.1.9 released
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,48 @@ Sherman can simulate ungapped high-throughput datasets for bisulfite sequencing 
 - Introduce a variable number of random SNPs into each read
 - Introduce a fixed amount of adapter sequence at the 3' end of all sequences
 - Introduce a variable amount of adapter sequence at various positions at the 3' end of reads
-- Write out a truth set of introduced bisulfite conversions ('positional_changes.txt')
+- Write out a truth set of introduced bisulfite conversions ('positional_changes.txt'), with genomic coordinates that are correct for both strands and both mates
+- Simulate **amplicon** libraries from fixed loci supplied as a BED file (`--amplicon_bedfile`)
+- Optionally use BWA-style `/1` and `/2` paired-end read-name suffixes (`--bwa_ending`)
+
+## Quick start
+
+```bash
+# Random single-end reads, 90% bisulfite conversion
+./Sherman --length 50 --number_of_seqs 100000 --conversion_rate 90
+
+# Genomic paired-end reads from a genome folder, with a truth set of converted positions
+./Sherman --genome_folder /path/to/genome --length 100 --number_of_seqs 1000000 \
+          --paired_end --conversion_rate 99 --truth_set
+
+# Context-specific conversion (different rates for CpG and non-CpG cytosines)
+./Sherman --genome_folder /path/to/genome -l 100 -n 1000000 --paired_end -CG 80 -CH 2
+
+# Amplicon mode: simulate reads for fixed loci listed in a 4-column BED (chr, start, end, strand)
+./Sherman --genome_folder /path/to/genome -l 100 -n 100000 --paired_end \
+          --amplicon_bedfile amplicons.bed --conversion_rate 95 --truth_set
+```
+
+The genome folder should contain one or more FastA files (`.fa`/`.fasta`). Output is written as
+`simulated.fastq` (single-end) or `simulated_1.fastq` / `simulated_2.fastq` (paired-end).
+
+## Notable options
+
+| Option | Description |
+| --- | --- |
+| `-l/--length <int>` | Read length |
+| `-n/--number_of_seqs <int>` | Number of reads (or read pairs) to generate |
+| `--genome_folder <path>` | Extract reads from a real genome instead of random sequence |
+| `--paired_end` | Generate paired-end data (`simulated_1/2.fastq`) |
+| `-cr/--conversion_rate <0-100>` | Uniform bisulfite conversion rate for all cytosines |
+| `-CG / -CH <0-100>` | Context-specific conversion rates (CpG vs non-CpG); used together |
+| `--non_directional` | Reads can originate from any of the four bisulfite strands |
+| `--truth_set` | Write `positional_changes.txt` (chromosome, position, context) of every converted cytosine |
+| `--amplicon_bedfile <file>` | Amplicon mode (paired-end): simulate reads for fixed loci from a 4-column, 0-based half-open BED |
+| `--bwa_ending` | Use `xxx/1` and `xxx/2` paired-end read names (instead of `xxx_R1` / `xxx_R2`) for BWA-based aligners |
+
+Run `./Sherman --help` for the full list of options. For more detailed information please refer to the
+[Sherman User Manual](Sherman_User_Manual.md).
 
 ## Sherman_Nanopore
 

--- a/Sherman
+++ b/Sherman
@@ -45,7 +45,7 @@ my @DNA_bases = ('A','T','C','G');
 my @gaussian; # will hold random fragment lengths
 
 my ($sequence_length,$conversion_rate,$number_of_sequences,$error_rate,$number_of_SNPs,$quality,$fixed_length_adapter,$variable_length_adapter,$adapter_dimer,$random,$colorspace,
-$genome_folder,$non_directional,$CG_conversion_rate,$CH_conversion_rate,$paired_end,$minfrag,$maxfrag,$output_dir,$truth_set,$amplicon) = process_command_line();
+$genome_folder,$non_directional,$CG_conversion_rate,$CH_conversion_rate,$paired_end,$minfrag,$maxfrag,$output_dir,$truth_set,$amplicon,$bwa_ending) = process_command_line();
 
 print_onscreen_summary();
 run_sequence_generation();
@@ -607,12 +607,22 @@ sub print_sequences_out_basespace{
       # sleep(1);
 
 
-      print FASTQ_R1 "\@${count}_${coord}_R1\n";
+      if ($bwa_ending){
+        print FASTQ_R1 "\@${count}_${coord}/1\n";
+      }
+      else{
+        print FASTQ_R1 "\@${count}_${coord}_R1\n";
+      }
       print FASTQ_R1 "$seq_1\n";
       print FASTQ_R1 "+\n";
       print FASTQ_R1 "$qual\n";
 
-      print FASTQ_R2 "\@${count}_${coord}_R2\n";
+      if ($bwa_ending){
+        print FASTQ_R2 "\@${count}_${coord}/2\n";
+      }
+      else{
+        print FASTQ_R2 "\@${count}_${coord}_R2\n";
+      }
       print FASTQ_R2 "$seq_2\n";
       print FASTQ_R2 "+\n";
       print FASTQ_R2 "$qual\n";
@@ -633,12 +643,22 @@ sub print_sequences_out_basespace{
   else{ # random reads
   ### paired-end
     if (defined $seq_2){
-      print FASTQ_R1 '@',$count,"_R1\n";
+      if ($bwa_ending){
+        print FASTQ_R1 '@',$count,"/1\n";
+      }
+      else{
+        print FASTQ_R1 '@',$count,"_R1\n";
+      }
       print FASTQ_R1 "$seq_1\n";
       print FASTQ_R1 "+\n";
       print FASTQ_R1 "$qual\n";
 
-      print FASTQ_R2 '@',$count,"_R2\n";
+      if ($bwa_ending){
+        print FASTQ_R2 '@',$count,"/2\n";
+      }
+      else{
+        print FASTQ_R2 '@',$count,"_R2\n";
+      }
       print FASTQ_R2 "$seq_2\n";
       print FASTQ_R2 "+\n";
       print FASTQ_R2 "$qual\n";
@@ -1714,6 +1734,7 @@ sub process_command_line{
 	my $output_dir;
   my $truth_set;
   my $amplicon_bed;
+  my $bwa_ending; # for paired-end reads, name read IDs xxx/1 and xxx/2 (instead of xxx_R1 / xxx_R2) for BWA-style aligners
 
 	my $command_line = GetOptions (
 				'help|man'                   => \$help,
@@ -1739,6 +1760,7 @@ sub process_command_line{
 				'output_dir=s'               => \$output_dir,
         'truth_set'                  => \$truth_set,
         'amplicon_bedfile=s'         => \$amplicon_bed,
+        'bwa_ending'                 => \$bwa_ending,
  				);
 
 
@@ -2062,7 +2084,7 @@ VERSION
   }
 
   return ($length,$conversion_rate,$number_of_seqs,$error_rate,$snps,$quality,$fixed_length_adapter,$variable_length_adapter,$adapter_dimer,$random,
-  $colorspace,$genome_folder,$non_directional,$CG_conversion_rate,$CH_conversion_rate,$paired_end,$minfrag,$maxfrag,$output_dir,$truth_set,$amplicon_bed);
+  $colorspace,$genome_folder,$non_directional,$CG_conversion_rate,$CH_conversion_rate,$paired_end,$minfrag,$maxfrag,$output_dir,$truth_set,$amplicon_bed,$bwa_ending);
 }
 
 sub print_helpfile{
@@ -2132,6 +2154,10 @@ BASIC ATTRIBUTES:
                                   be tab-delimited with 4 columns: chromosome, start, end, strand (+/-). Coordinates are
                                   0-based and half-open (as is custom for BED). Supply primer-trimmed coordinates if you do
                                   not want the primer regions to receive simulated methylation/conversion.
+
+--bwa_ending                      For paired-end reads, name the read IDs using the BWA-style scheme >> xxx/1 << and
+                                  >> xxx/2 << instead of the default >> xxx_R1 << and >> xxx_R2 <<. This makes the FastQ
+                                  files compatible with BWA-based aligners that expect /1 and /2 mate suffixes. Default: OFF.
 
 
 CONTAMINANTS:


### PR DESCRIPTION
Forward-ports the `--bwa_ending` option from the `dev` branch (it never reached `master`), adapted to master's current `process_command_line` signature, and brings the CHANGELOG/README up to date.

## --bwa_ending
For paired-end reads, names read IDs `xxx/1` and `xxx/2` (BWA-style) instead of the default `xxx_R1` / `xxx_R2`, for compatibility with BWA-based aligners. Applies to both genomic and random paired-end reads; single-end reads (no mate suffix) are unaffected. Default: OFF. Addresses #5.

```
default:        @1_chr1:276-556_R1   @1_chr1:276-556_R2
--bwa_ending:   @1_chr1:276-556/1    @1_chr1:276-556/2
```

## Docs
- **CHANGELOG** — added an `Unreleased` section documenting both new options (`--amplicon_bedfile`, `--bwa_ending`) and the three fixes already merged but never recorded: the `--truth_set` coordinate correction (#15), the context-specific crash fix, and the multi-contig fragment fix.
- **README** — added amplicon / `--bwa_ending` / truth-set entries to the feature list, plus a **Quick start** and **Notable options** section with concrete commands (previously the README had no usage examples).

## Why port (not merge dev)
`dev` and `master` have diverged; everything else on `dev` is either already on `master` (amplicon, in a corrected state — #19) or superseded by the #17/#18 rewrites (`dev`'s "negative offset" commit is only debug `warn`/`die` scaffolding, not a real fix). `--bwa_ending` was the one genuinely useful dev-only addition.

## Testing
PE genomic and random reads emit `/1` and `/2` under `--bwa_ending` and `_R1`/`_R2` by default; SE unchanged; `perl -c` passes.